### PR TITLE
Rename global Contact Us to Contact UW

### DIFF
--- a/inc/nav/footermenu.php
+++ b/inc/nav/footermenu.php
@@ -65,7 +65,7 @@ class UW_FooterMenu {
 
 		// The default footer menu.
 		$this->add_menu_item( 'Accessibility', 'https://www.washington.edu/accessibility/' );
-		$this->add_menu_item( 'Contact Us', 'https://www.washington.edu/contact/' );
+		$this->add_menu_item( 'Contact UW', 'https://www.washington.edu/contact/' );
 		$this->add_menu_item( 'Jobs', 'https://www.washington.edu/jobs/' );
 		$this->add_menu_item( 'Campus Safety', 'https://www.washington.edu/safety/' );
 		$this->add_menu_item( 'My UW', 'https://my.uw.edu/' );


### PR DESCRIPTION
This improves accessibility by preventing the same link text "Contact Us" from going to two separate websites if "Contact Us" is used by the website's owner to refer to their own department.